### PR TITLE
Add option to skip getting connection id

### DIFF
--- a/app/src/main/java/com/smartarmenia/websocketclient/MainActivity.kt
+++ b/app/src/main/java/com/smartarmenia/websocketclient/MainActivity.kt
@@ -30,7 +30,7 @@ class MainActivity : AppCompatActivity(), HubConnectionListener, HubEventListene
     }
 
     private val authHeader = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6Ijc5NzhjMjI3LWViMGItNGMwOS1iYWEyLTEwYmE0MjI4YWE4OSIsImNlcnRzZXJpYWxudW1iZXIiOiJtYWNfYWRkcmVzc19vZl9waG9uZSIsInNlY3VyaXR5U3RhbXAiOiJlMTAxOWNiYy1jMjM2LTQ0ZTEtYjdjYy0zNjMxYTYxYzMxYmIiLCJuYmYiOjE1MDYyODQ4NzMsImV4cCI6NDY2MTk1ODQ3MywiaWF0IjoxNTA2Mjg0ODczLCJpc3MiOiJCbGVuZCIsImF1ZCI6IkJsZW5kIn0.QUh241IB7g3axLcfmKR2899Kt1xrTInwT6BBszf6aP4"
-    private val connection: HubConnection = WebSocketHubConnectionP2("http://192.168.1.8:5002/signalr/hubs/auth", authHeader)
+    private val connection: HubConnection = WebSocketHubConnectionP2("http://192.168.1.8:5002/signalr/hubs/auth", authHeader, false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/dotnetcoresignalrclientjava/src/main/java/com/smartarmenia/dotnetcoresignalrclientjava/WebSocketHubConnectionP2.java
+++ b/dotnetcoresignalrclientjava/src/main/java/com/smartarmenia/dotnetcoresignalrclientjava/WebSocketHubConnectionP2.java
@@ -38,10 +38,12 @@ public class WebSocketHubConnectionP2 implements HubConnection {
 
     private String connectionId = null;
     private String authHeader;
+    private boolean skipConnectionId;
 
-    public WebSocketHubConnectionP2(String hubUrl, String authHeader) {
+    public WebSocketHubConnectionP2(String hubUrl, String authHeader, boolean skipGettingConnectionId) {
         this.authHeader = authHeader;
         parsedUri = Uri.parse(hubUrl);
+        skipConnectionId = skipGettingConnectionId;
     }
 
     @Override
@@ -50,7 +52,7 @@ public class WebSocketHubConnectionP2 implements HubConnection {
             return;
 
         Runnable runnable;
-        if (connectionId == null) {
+        if (connectionId == null && !skipConnectionId) {
             runnable = new Runnable() {
                 public void run() {
                     getConnectionId();
@@ -113,7 +115,9 @@ public class WebSocketHubConnectionP2 implements HubConnection {
 
     private void connectClient() {
         Uri.Builder uriBuilder = parsedUri.buildUpon();
-        uriBuilder.appendQueryParameter("id", connectionId);
+        if (!skipConnectionId) {
+            uriBuilder.appendQueryParameter("id", connectionId);
+        }
         uriBuilder.scheme(parsedUri.getScheme().replace("http", "ws"));
         Uri uri = uriBuilder.build();
         Map<String, String> headers = new HashMap<>();


### PR DESCRIPTION
Added option to skip getting connectionId, since signalr stable version supports bare websocket connection.